### PR TITLE
Fixing a 422 error from the Airtable API when serving a call

### DIFF
--- a/netlify/lib/log.js
+++ b/netlify/lib/log.js
@@ -7,14 +7,14 @@ module.exports.logEvent = ({ event, context, endpoint, payload, name }) => {
   // save off raw report ASAP. Note that we don't block on this
   // completing, so it shouldn't slow things down too much.
   try {
-    const auth0ReporterId =
+    const auth0_reporter_id =
       context &&
       context.identityContext &&
       context.identityContext.claims &&
       context.identityContext.claims.sub;
 
     const fields = {
-      auth0ReporterId,
+      auth0_reporter_id,
       endpoint,
       payload,
       event_name: name,
@@ -29,7 +29,7 @@ module.exports.logEvent = ({ event, context, endpoint, payload, name }) => {
             "EVENTLOG",
             endpoint,
             name,
-            auth0ReporterId,
+            auth0_reporter_id,
             results[0].id
           );
         } else {


### PR DESCRIPTION
```
Failed to insert audit log err: AirtableError {
  error: 'UNKNOWN_FIELD_NAME',
  message: 'Unknown field name: "auth0ReporterId"',
  statusCode: 422
}
```
The field is spelled `autho0_report_id` in the `call_report_event_log` and `Reports` tables, we should probably send it spelt that way.