### PR TITLE
We were not properly re-initializing the call report on each load, leading to data from previous reports potentially leaking

### DIFF
--- a/apps/assets/js/main.js
+++ b/apps/assets/js/main.js
@@ -31,7 +31,7 @@ import errorModalTemplate from "./templates/errorModal.handlebars";
 // global auth0 object. probably a better way to do this
 let auth0 = null;
 
-const currentReport = {};
+let currentReport = {};
 let currentLocation = null;
 let previousLocation = null;
 
@@ -232,6 +232,7 @@ const recordCall = async (callReport) => {
 };
 
 const initializeReport = (locationId) => {
+  currentReport = {};
   currentReport["Location"] = locationId;
 };
 


### PR DESCRIPTION
affected fields are believed to be

"Appointments by phone?"
"Appointment scheduling instructions"
"Do not call until"

if these fields were not filled out in the new report 