### PR TITLE
Tulare is 16+

### DIFF
--- a/netlify/functions/submitReport/index.js
+++ b/netlify/functions/submitReport/index.js
@@ -26,6 +26,7 @@ const FULLY_OPENED_COUNTIES = new Set([
   "Butte County",
   "Contra Costa County",
   "Stanislaus County",
+  "Tulare County",
 ]);
 
 class HTTPResponseError extends Error {


### PR DESCRIPTION
https://tchhsa.org/eng/index.cfm/public-health/covid-19-in-tulare-county/covid-19-news-releases1/march-31-2021-news-release-tulare-county-now-vaccinating-anyone-age-16-and-older-at-tulare-international-agri-center/

![Screen Shot 2021-04-01 at 11 29 13 AM](https://user-images.githubusercontent.com/28347/113338139-8d3dd700-92dd-11eb-90cb-ab9de15c0c73.png)
