### PR TITLE
submitReport: Don't flag skips, even from trainees or journeymen.

### DIFF
--- a/netlify/functions/submitReport/index.js
+++ b/netlify/functions/submitReport/index.js
@@ -40,12 +40,17 @@ class HTTPResponseError extends Error {
 }
 
 function shouldReview(event, roles) {
-  // Flag based on user roles; 100% of trainee, 15% of journeyman
-  if (roles.includes(TRAINEE_ROLE_NAME)) {
-    return true;
-  } else if (roles.includes(JOURNEYMAN_ROLE_NAME)) {
-    if (Math.random() < 0.15) {
+  const tags = new Set(event.Availability);
+
+  // We never flag skips, unless they explicitly ask for review
+  if (!tags.has(SKIP_TAG_PREFIX)) {
+    // For non-skips, flag based on user roles; 100% of trainee, 15% of journeyman
+    if (roles.includes(TRAINEE_ROLE_NAME)) {
       return true;
+    } else if (roles.includes(JOURNEYMAN_ROLE_NAME)) {
+      if (Math.random() < 0.15) {
+        return true;
+      }
     }
   }
 
@@ -63,7 +68,6 @@ function shouldReview(event, roles) {
   }
 
   // Flag based on tags that we expect to be very infrequent
-  const tags = new Set(event.Availability);
   let potentiallySuspectTags = REVIEW_ALWAYS_TAGS;
   if (event.County && !FULLY_OPENED_COUNTIES.has(event.County)) {
     // Add the age tags, unless they're fully open


### PR DESCRIPTION
We don't simply accept all skips, since these reports can still be
flagged for including phone numbers or emails in public notes, or if
they explicitly checked the box.

/cc @kimberlyd17 