### PR TITLE
Prefill scooby public and private notes with the current date

### DIFF
--- a/apps/assets/js/main.js
+++ b/apps/assets/js/main.js
@@ -562,7 +562,9 @@ const fillCallTemplate = (data) => {
   });
 
   noteTimestampPrefix = `${new Date().toLocaleString("en-US", { month: "short", day: "numeric" })}: `;
-  prefilledInternalNotes = `${noteTimestampPrefix}\n\n${data["Latest Internal Notes"] || ""}`;
+  prefilledInternalNotes = !!data["Latest Internal Notes"]
+    ? `${noteTimestampPrefix}\n\n${data["Latest Internal Notes"] || ""}`
+    : noteTimestampPrefix;
   fillTemplateIntoDom(callScriptTemplate, "#callScript", {
     locationId: data.id,
     locationAddress: data.Address,

--- a/netlify/functions/submitReport/index.js
+++ b/netlify/functions/submitReport/index.js
@@ -81,9 +81,9 @@ function shouldReview(event, roles) {
     [...tags].filter((value) => REVIEW_IF_UNCHANGED_NOTES_TAGS.has(value))
       .length
   ) {
-    // Note that we trust the client to tell us if the internal notes are 
+    // Note that we trust the client to tell us if the internal notes are
     // unchanged; a malicious client could thus fake having changed the internal
-    // notes in order to escape being flagged.  A more correct implementation 
+    // notes in order to escape being flagged.  A more correct implementation
     // would be to HMAC sign the internal notes in requestCall, and verify that
     // signature and compare it to a regenerate version of that here.
     if (event["internal_notes_unchanged"]) {


### PR DESCRIPTION
Per call with @alecfwilson, @rhkeeler, and others, we have landed on the following:

1) Prefill the current date into the public and private note fields.

2) If the user does not modify this public note field, do not actually submit it.

3) If the user does not modify the private note field, that is okay and it useful on it's own to know that.


To make this work, I had to modify the API layer a bit as it was previously diffing the previous value of the internal notes field with the current value. Given that the internal notes field is guaranteed to change each submission, that no longer makes sense. Instead, I now hold onto the "prefilled" internal notes text and diff that.

<img width="964" alt="Screen Shot 2021-04-01 at 2 36 48 PM" src="https://user-images.githubusercontent.com/690859/113356805-b9665180-92f7-11eb-9461-604e74ebf4c2.png">
