### PR TITLE
Caller stats changed to display week

### DIFF
--- a/apps/assets/js/main.js
+++ b/apps/assets/js/main.js
@@ -63,7 +63,7 @@ const initCallerStatsTemplate = () => {
   fillTemplateIntoDom(callerStatsTemplate, "#callerStats", {
     displayCallerStats: !!callerStats,
     callsToday: callerStats?.today,
-    callsTotal: callerStats?.total,
+    callsThisWeek: callerStats?.week,
   });
 };
 
@@ -482,7 +482,7 @@ const submitCallReport = async () => {
     if (callId) {
       callerStats = {
         today: callerStats ? callerStats.today + 1 : 1,
-        total: callerStats ? callerStats.total + 1 : 1,
+        week: callerStats ? callerStats.week + 1 : 1,
       };
       showCompletionToast(currentLocation.Name);
 

--- a/apps/assets/js/templates/callerStats.handlebars
+++ b/apps/assets/js/templates/callerStats.handlebars
@@ -1,3 +1,3 @@
 <div {{#if displayCallerStats}} class="text-success" {{else}} class="text-success invisible" {{/if}}>
-    <span>You've made <strong>{{callsToday}}</strong> calls today and <strong>{{callsTotal}}</strong> calls total.</span>
+    <span>You've made <strong>{{callsToday}}</strong> calls today and <strong>{{callsThisWeek}}</strong> calls in the past week.</span>
 </div>

--- a/netlify/functions/callerStats/index.js
+++ b/netlify/functions/callerStats/index.js
@@ -37,6 +37,13 @@ const handler = async (event, context, logger) => {
   // total number of reports i've filed
   output.total = stats.length;
 
+  // how many of them are in the past week
+  const weekAgo = new Date();
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  output.week = stats.filter(
+    (r) => new Date(r.get("time")).getTime() >= weekAgo.getTime()
+  ).length;
+
   // how many of them are today (PST)
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Los_Angeles",


### PR DESCRIPTION
Updated caller stats api to also return `week` data. I calculated this by just grabbing the current timestamp, subtracting 7 days, and comparing times. I kept in the total field in the API just because it doesn't hurt to keep sending it and that way older clients don't break on transition