### PR TITLE
Add "Website and Phone" button for when you can book with either

### DIFF
--- a/apps/assets/js/templates/callScript.handlebars
+++ b/apps/assets/js/templates/callScript.handlebars
@@ -323,11 +323,20 @@
                   class="btn-check"
                   type="radio"
                   name="appointmentMethod"
+                  id="appointmentMethodBoth"
+                  data-show-also="appointmentOtherInstructions"
+                  value="other"
+                />
+                <label for="appointmentMethodBoth" class="btn btn-outline-secondary">Website and Phone</label>
+                <input
+                  class="btn-check"
+                  type="radio"
+                  name="appointmentMethod"
                   id="appointmentMethodOther"
                   data-show-also="appointmentOtherInstructions"
                   value="other"
                 />
-                <label for="appointmentMethodOther" class="btn btn-outline-secondary">Another way</label>
+                <label for="appointmentMethodOther" class="btn btn-outline-secondary">Some other way</label>
               </div>
               <div id="appointmentMethodDetail" class="mt-2">
                 <input


### PR DESCRIPTION
"Another way" sounds like "not web or phone", but in cases where both exist, we'd like them to provide both of them in the box.

<img width="812" alt="Screen Shot 2021-04-02 at 9 28 22 PM" src="https://user-images.githubusercontent.com/28347/113468139-61fcda00-93fa-11eb-8059-13a407d7000f.png">

