### PR TITLE
scooby: Link to the more general Walmart COVID vaccine page.

### DIFF
--- a/apps/assets/js/templates/affiliationNotes.handlebars
+++ b/apps/assets/js/templates/affiliationNotes.handlebars
@@ -1,7 +1,7 @@
 <div class="small">
   <div
     class="provider walmart"
-    data-scheduling-url="https://www.walmart.com/pharmacy/clinical-services/immunization/scheduled?imzType=covid"
+    data-scheduling-url="https://www.walmart.com/cp/1228302"
     >Press 0 to go directly to the pharmacy.</div
   >
   <div class="provider safeway vons" data-scheduling-url="https://www.mhealthappointments.com/covidappt">


### PR DESCRIPTION
This page is more of a "landing" page.  The previous link is the more
direct link -- it takes you where the "Schedule now" button on the
landing page points to -- but it can be confusing to be dumped into a
contextless login page, with no hint that this is, indeed, for COVID
vaccines.

While it requires one more click, it likely reduces the bounce rate to
provide users with the necessary context.