### PR TITLE
Add appointment scheduling URLs for Lucky/Save Mart pharmacies

### DIFF
--- a/apps/assets/js/templates/affiliationNotes.handlebars
+++ b/apps/assets/js/templates/affiliationNotes.handlebars
@@ -30,7 +30,7 @@
       <li>Press 4 to talk to a pharmacist.</li>
     </ul>
   </div>
-  <div class="provider lucky">
+  <div class="provider lucky" data-scheduling-url="https://savemartluckysched.rxtouch.com/smsched/program/covid19/Patient/Advisory">
     <ul>
       <li>Press 1 to go to the pharmacy</li>
       <li>Press 3 to to talk to a pharmacist</li>
@@ -62,6 +62,8 @@
 
     <div> If the CVS is in a Target and the number's for Target, you can press '3' for the pharmacy. </div>
   </div>
+
+  <div class="provider savemart" data-scheduling-url="https://savemartluckysched.rxtouch.com/smsched/program/covid19/Patient/Advisory"></div>
 
   <div class="provider none--unknown--unimportant"></div>
 </div>


### PR DESCRIPTION
Shows up like this:
![image](https://user-images.githubusercontent.com/91915/113632106-635b1c00-961f-11eb-867b-acc7b9a4e5ea.png)
