### PR TITLE
fix: Call the Shots, Inc. as copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 California Vaccine Inventory
+Copyright (c) 2021 Call the Shots, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
California Vaccine Inventory was an early name for the organization now known as Call the Shots, Inc.

Clarify the copyright notice to refer to the final name.