### PR TITLE
Improve scooby error handling

### DIFF
--- a/apps/assets/js/main.js
+++ b/apps/assets/js/main.js
@@ -60,6 +60,11 @@ let prefilledInternalNotes = null;
 
 const initCallerStats = async () => {
   callerStats = await fetchJsonFromEndpoint("/.netlify/functions/callerStats");
+  if (callerStats.error) {
+    // just swallow and hide since not critical
+    console.warn("error fetching callerStats: ", callerStats);
+    callerStats = null;
+  }
   initCallerStatsTemplate();
 };
 
@@ -119,8 +124,13 @@ const fetchJsonFromEndpoint = async (endpoint, method, body) => {
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  const data = await result.json();
-  return data;
+
+  try {
+    return await result.json();
+  } catch (e) {
+    // didnt get json back - treat as an error
+    return { error: true, error_description: result.statusText };
+  }
 };
 
 const doLogin = () => {


### PR DESCRIPTION
Scooby right now assumes you get a json response back from the server. that is usually true, but sometimes in rare circumstances we can encounter server issues that come back malformed as, say, a 500 error html page.

This PR modifies the logic in scooby to always ensure some form of json is received by massaging non-json into error json. Also updated the callerstats initialization to deal with this problem.