### PR TITLE
First pass at improving webbank UX

### DIFF
--- a/apps/assets/js/main.js
+++ b/apps/assets/js/main.js
@@ -50,6 +50,7 @@ let userRoles = null;
 let currentReport = {};
 let currentLocation = null;
 let previousLocation = null;
+let previousId = null;
 
 let previousCallScriptDom = null;
 
@@ -216,8 +217,14 @@ const loadAndFillPreviousCall = () => {
   hideElement("#nextCallPrompt");
   showElement("#callerTool");
   hideToast(); // should do this somewhere smarter.
+
   currentLocation = previousLocation;
+  if (previousId) {
+    window.history.replaceState({}, "", `${window.location.pathname}?location_id=${previousId}`);
+  }
+
   previousLocation = null;
+  previousId = null;
   showScriptForLocation(currentLocation);
   // Replace the call script with the call script from the previous report
   const callScript = document.getElementById("callScript");
@@ -258,6 +265,11 @@ const initScooby = () => {
         document.querySelector("#location-phone-url")?.click();
       }
     });
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("location_id")) {
+      authOrLoadAndFillCall();
+    }
   });
 };
 
@@ -554,8 +566,9 @@ const submitCallReport = async () => {
       previousLocation = currentLocation;
       previousCallScriptDom = document.getElementById("callScript").cloneNode(1);
       const urlParams = new URLSearchParams(window.location.search);
+      previousId = urlParams.get("location_id");
 
-      if (urlParams.get("location_id")) {
+      if (previousId) {
         // If using scooby via location_id, reset to home view instead of requesting more calls
         urlParams.delete("location_id");
         window.history.replaceState({}, "", `${window.location.pathname}?${urlParams.toString()}`);


### PR DESCRIPTION
original discussion in https://github.com/CAVaccineInventory/vial/issues/277

Right now, if you are a webbanker, you reach scooby via the location_id url param. This works great, but it has the issue that completing a web bank report assumes you are a caller who wants to keep calling.

To address this, if the location_id url param is present:
- I immediately navigate you to the form UI instead of waiting for you to press the request a call button 
- Upon completion of the form, you are kicked out to the home view instead of requesting a new call.

This is certainly not perfect, and there is a lot of opportunity to continue to improve the webbank experience.  But probably a good starting point.