### PR TITLE
Switch tag wording to be "walk-ins only" to match the button.

### DIFF
--- a/apimapping.md
+++ b/apimapping.md
@@ -21,7 +21,7 @@ Sets `Vaccines offered` as an array of values: `["Moderna", "Pfizer", "Johnson &
 
 - Appointment Required - Adds availability tag `Yes: appointment required`
 - Accept appointments and walk-ins - Adds availability tag `Yes: appointments or walk-ins accepted`
-- Walk-ins only - Adds availability tag `Yes: walk-ins accepted`
+- Walk-ins only - Adds availability tag `Walk-ins only`
 
 ***If nothing is selected, defaults to `Yes: appointment required`***
 

--- a/apps/assets/js/scooby.js
+++ b/apps/assets/js/scooby.js
@@ -246,8 +246,8 @@ const constructReportFromDom = () => {
     // And do you require appointments, or are walk-ins accepted?
     const apptRequired = document.querySelector("[name=appointmentRequired]:checked")?.value;
     switch (apptRequired) {
-      case "walkinOk":
-        availability.push("Yes: walk-ins accepted");
+      case "walkinOnly":
+        availability.push("Walk-ins only");
         break;
       case "required":
         availability.push("Yes: appointment required");

--- a/apps/assets/js/scooby/validators.js
+++ b/apps/assets/js/scooby/validators.js
@@ -8,8 +8,8 @@ const PERM_CLOSED_BLOCK =
   "Before we mark a site as being permanently closed, we'd like some more information about why. Fill in the private notes field with as much information as you can about what the location told you.";
 const PRIVATE_ONLY_BLOCK =
   "Before we mark a site as not being open to the public, we'd like some more information about why. Please fill in the private notes field with as much information as you can about what the location told you.";
-const WALKINS_ACCEPTED_BLOCK =
-  "In general, locations that allow walk-ins are rare. Fill in the private notes field with details about what the pharmacist told you.";
+const WALKINS_ONLY_BLOCK =
+  "In general, locations that only allow walk-ins are rare. Fill in the private notes field with details about what the pharmacist told you.";
 const INVALID_DATE_FORMAT_BLOCK =
   "The date that was entered for when the site will stop offering vaccines was not in a format we recognize. If you are using Safari, that would be yyyy-mm-dd. For example: 2021-05-25.";
 const OTHER_VACCINE_BLOCK =
@@ -20,11 +20,11 @@ const AVAIL_TO_BLOCKING_ISSUES = {
   "No: will never be a vaccination site": NEVER_BLOCK,
   "No: location permanently closed": PERM_CLOSED_BLOCK,
   "No: not open to the public": PRIVATE_ONLY_BLOCK,
-  "Yes: walk-ins accepted": WALKINS_ACCEPTED_BLOCK,
+  "Yes: walk-ins only": WALKINS_ONLY_BLOCK,
   "Yes: appointments or walk-ins accepted": WALKINS_ACCEPTED_BLOCK,
 };
 
-const ALWAYS_REVIEW_CALL_TAGS = new Set(["Yes: walk-ins accepted"]);
+const ALWAYS_REVIEW_CALL_TAGS = new Set(["Yes: walk-ins only"]);
 
 const phoneNumberRegex = /\s+(\+?\d{1,2}(\s|-)*)?(\(\d{3}\)|\d{3})(\s|-)*\d{3}(\s|-)*\d{4}/;
 const emailRegex = /\S+@\S+\.\S+/; // This is very much not RFC-compliant, but generally matches common addresses.

--- a/apps/assets/js/templates/scooby/callScript.handlebars
+++ b/apps/assets/js/templates/scooby/callScript.handlebars
@@ -162,7 +162,7 @@
           class="btn-check"
           type="radio"
           name="appointmentRequired"
-          value="walkinOk"
+          value="walkinOnly"
           id="apptWalkin"
           data-hide-on-select="appointmentDetails"
           data-show-also="walkin-warning"


### PR DESCRIPTION
Ref CAVaccineInventory/vial#587, must be deployed after the VIAL change.